### PR TITLE
Uses provided Vue instead of own Vue

### DIFF
--- a/lib/appInstantiator.js
+++ b/lib/appInstantiator.js
@@ -1,4 +1,4 @@
-const Vue = require('vue').default || require('vue');
+const MoisturizerVuePlugin = require('./moisturizerVuePlugin');
 
 class AppInstantiator {
 	constructor(component, vueOptions = {}) {
@@ -6,9 +6,9 @@ class AppInstantiator {
 		this.vueOptions = vueOptions;
 	}
 
-	instantiate(v = Vue) {
+	instantiate() {
 		const render = h => h(this.component);
-		return new v({ ...this.vueOptions, render });
+		return new MoisturizerVuePlugin.vue({ ...this.vueOptions, render });
 	}
 }
 

--- a/lib/hydrator.js
+++ b/lib/hydrator.js
@@ -20,7 +20,7 @@ class Hydrator {
 		const attr = config.attrs.fingerprint;
 		const fingerprint = Fingerprinter.print(component);
 		const elements = document.querySelectorAll(`[${attr}="${fingerprint}"]`);
-		[...elements].map(el => this.mount(component, el));
+		[...elements].forEach(el => this.mount(component, el));
 	}
 
 	mount(component, el) {
@@ -42,7 +42,9 @@ class Hydrator {
 			render(createElement) {
 				if (component.props) {
 					const propNames = Object.entries(component.props).map(x => x[0]);
-					const attrs = Object.entries(attributes).filter(x => !propNames.includes(x[0]));
+					const attrs = Object.entries(attributes)
+						.filter(x => !propNames.includes(x[0]))
+						.reduce((obj, [key, val]) => ({ ...obj, [key]: val }), {});
 					const props = { ...propsData, ...attributes };
 					return createElement(component, { attrs, props, scopedSlots });
 				} else {

--- a/lib/hydrator.js
+++ b/lib/hydrator.js
@@ -1,4 +1,4 @@
-const Vue = require('vue').default || require('vue');
+const MoisturizerVuePlugin = require('./moisturizerVuePlugin');
 const Validator = require('./validator');
 const Fingerprinter = require('./fingerprinter');
 const config = require('./config');
@@ -25,8 +25,7 @@ class Hydrator {
 
 	mount(component, el) {
 		const props = new Props(this.components).getFromElement(el);
-		const slots = new Slots(this.components).getFromElement(el);
-		// Filter data attributes
+		const slots = new Slots(this.components, MoisturizerVuePlugin.vue).getFromElement(el);
 		const htmlAttrs = [...el.attributes].filter(a => !a.name.startsWith('data-hydrate'));
 		const attrObjects = [...htmlAttrs].map(attr => ({ [attr.name]: attr.value }));
 		const attrMap = Object.assign({}, ...attrObjects);
@@ -39,7 +38,7 @@ class Hydrator {
 		const toFunction = ([name, slts]) => ({ [name]: () => slts });
 		const scopedSlots = Object.assign({}, ...slotObjects.map(toFunction));
 
-		const Constr = Vue.extend({
+		const Constr = MoisturizerVuePlugin.vue.extend({
 			render(createElement) {
 				if (component.props) {
 					const propNames = Object.entries(component.props).map(x => x[0]);

--- a/lib/hydrator.js
+++ b/lib/hydrator.js
@@ -25,7 +25,7 @@ class Hydrator {
 
 	mount(component, el) {
 		const props = new Props(this.components).getFromElement(el);
-		const slots = new Slots(this.components, MoisturizerVuePlugin.vue).getFromElement(el);
+		const slots = new Slots(this.components).getFromElement(el);
 		const htmlAttrs = [...el.attributes].filter(a => !a.name.startsWith('data-hydrate'));
 		const attrObjects = [...htmlAttrs].map(attr => ({ [attr.name]: attr.value }));
 		const attrMap = Object.assign({}, ...attrObjects);

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,5 +3,5 @@ const AppInstantiator = require('./appInstantiator');
 const Hydrator = require('./hydrator');
 
 module.exports = MoisturizerVuePlugin;
-module.exports.instantiateApp = (comp, options, vue) => new AppInstantiator(comp, options).instantiate(vue);
+module.exports.instantiateApp = (comp, options) => new AppInstantiator(comp, options).instantiate();
 module.exports.hydrateComponents = (comps, options) => new Hydrator(comps, options).hydrate();

--- a/lib/moisturizerVuePlugin.js
+++ b/lib/moisturizerVuePlugin.js
@@ -5,13 +5,22 @@ const Slots = require('./slots');
 
 class MoisturizerVuePlugin {
 	static install(Vue) {
+		MoisturizerVuePlugin.setVue(Vue);
+		MoisturizerVuePlugin.applyMixin(Vue);
+	}
+
+	static setVue(Vue) {
+		MoisturizerVuePlugin.vue = Vue;
+	}
+
+	static applyMixin(Vue) {
 		Vue.mixin({
 			created() {
 				if (typeof window === 'undefined' && this.hydrate) {
 					MoisturizerVuePlugin.extendAttrs(this, {
 						[config.attrs.fingerprint]: MoisturizerVuePlugin.getFingerprint(this),
 						[config.attrs.props]: MoisturizerVuePlugin.getProps(this),
-						[config.attrs.slots]: MoisturizerVuePlugin.getSlots(this),
+						[config.attrs.slots]: MoisturizerVuePlugin.getSlots(this, Vue),
 					});
 				}
 			},
@@ -38,8 +47,8 @@ class MoisturizerVuePlugin {
 		return new Props([]).serialize(comp.$options.propsData);
 	}
 
-	static getSlots(comp) {
-		return new Slots().serialize(comp.$slots);
+	static getSlots(comp, Vue) {
+		return new Slots([], Vue).serialize(comp.$slots);
 	}
 }
 

--- a/lib/moisturizerVuePlugin.js
+++ b/lib/moisturizerVuePlugin.js
@@ -48,7 +48,7 @@ class MoisturizerVuePlugin {
 	}
 
 	static getSlots(comp) {
-		return new Slots([]).serialize(comp.$slots);
+		return new Slots().serialize(comp.$slots);
 	}
 }
 

--- a/lib/moisturizerVuePlugin.js
+++ b/lib/moisturizerVuePlugin.js
@@ -20,7 +20,7 @@ class MoisturizerVuePlugin {
 					MoisturizerVuePlugin.extendAttrs(this, {
 						[config.attrs.fingerprint]: MoisturizerVuePlugin.getFingerprint(this),
 						[config.attrs.props]: MoisturizerVuePlugin.getProps(this),
-						[config.attrs.slots]: MoisturizerVuePlugin.getSlots(this, Vue),
+						[config.attrs.slots]: MoisturizerVuePlugin.getSlots(this),
 					});
 				}
 			},
@@ -47,8 +47,8 @@ class MoisturizerVuePlugin {
 		return new Props([]).serialize(comp.$options.propsData);
 	}
 
-	static getSlots(comp, Vue) {
-		return new Slots([], Vue).serialize(comp.$slots);
+	static getSlots(comp) {
+		return new Slots([]).serialize(comp.$slots);
 	}
 }
 

--- a/lib/slots.js
+++ b/lib/slots.js
@@ -2,7 +2,8 @@ const Fingerprinter = require('./fingerprinter');
 const config = require('./config');
 
 class Slots {
-	constructor(components, Vue) {
+	constructor(components) {
+		const Vue = require('./moisturizerVuePlugin').vue;
 		this.components = components;
 		this.vm = new Vue({});
 	}

--- a/lib/slots.js
+++ b/lib/slots.js
@@ -1,9 +1,8 @@
-const Vue = require('vue').default || require('vue');
 const Fingerprinter = require('./fingerprinter');
 const config = require('./config');
 
 class Slots {
-	constructor(components) {
+	constructor(components, Vue) {
 		this.components = components;
 		this.vm = new Vue({});
 	}

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -1,3 +1,4 @@
+const hasDuplicates = require('has-duplicates');
 const Fingerprint = require('./fingerprinter');
 const config = require('./config');
 
@@ -9,7 +10,7 @@ class Validator {
 
 	validate() {
 		this.showWarningsForUnprovidedComponents();
-		this.throwErrorforDuplicateNames();
+		this.throwErrorforDuplicateFingerprints();
 	}
 
 	showWarningsForUnprovidedComponents() {
@@ -29,28 +30,13 @@ class Validator {
 		}
 	}
 
-	throwErrorforDuplicateNames() {
-		const duplicates = this.getDuplicates();
-		if (duplicates.length === 0) return;
-		const warning = 'You are trying to hydrate multiple components that have the same name!';
-		const advice = `Please provide different names for components using ${duplicates.join(
-			', '
-		)}`;
-		throw new Error(`${warning}\n${advice}`);
-	}
-
-	getDuplicates() {
-		return Object.values(this.groupComponents())
-			.filter(group => group.length > 1)
-			.map(comps => `"${comps[0].name}"`);
-	}
-
-	groupComponents() {
-		return this.components.reduce((dupes, comp) => {
-			dupes[comp.name] = dupes[comp.name] || [];
-			dupes[comp.name].push(comp);
-			return dupes;
-		}, {});
+	// TODO Tell the programmer which components are dupes
+	throwErrorforDuplicateFingerprints() {
+		if (hasDuplicates(this.fingerprints)) {
+			const warning = `You are trying to hydrate multiple components that have the same fingerprint!`;
+			const advice = `Please provide different names for components or use functional components`;
+			throw new Error(`${warning}\n${advice}`);
+		}
 	}
 }
 

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
 		"vue-template-compiler": "2.5.17"
 	},
 	"dependencies": {
+		"has-duplicates": "1.0.0",
 		"md5": "2.2.1"
 	}
 }

--- a/test/__snapshots__/hydrateComponents.test.js.snap
+++ b/test/__snapshots__/hydrateComponents.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`throws error if 2 components have the same name 1`] = `
-"You are trying to hydrate multiple components that have the same name!
-Please provide different names for components using \\"A\\", \\"B\\""
+"You are trying to hydrate multiple components that have the same fingerprint!
+Please provide different names for components or use functional components"
 `;

--- a/test/hydrateComponents.test.js
+++ b/test/hydrateComponents.test.js
@@ -11,127 +11,119 @@ import Conditional from './fixtures/components/Conditional.vue';
 import WithSlots from './fixtures/components/WithSlots.vue';
 import { mount } from '@vue/test-utils';
 
-
 test('applies template to containers without markup', () => {
-  const {mounted} = init([A, B]);
-  const aHTML = createHTMLNode('a', mounted[0].vm);
-  const bHTML = createHTMLNode('a', mounted[1].vm);
-  document.body.innerHTML = aHTML + bHTML;
-  hydrateComponents([A, B]);
-  expect(document.body.innerHTML).toBe('<a>A</a><a>B</a>');
+	const { mounted } = init([A, B]);
+	const aHTML = createHTMLNode('a', mounted[0].vm);
+	const bHTML = createHTMLNode('a', mounted[1].vm);
+	document.body.innerHTML = aHTML + bHTML;
+	hydrateComponents([A, B]);
+	expect(document.body.innerHTML).toBe('<a>A</a><a>B</a>');
 });
 
 test('applies template to containers with mismatching markup', () => {
-  const {mounted} = init([A]);
-  document.body.innerHTML = createHTMLNode('a', mounted[0].vm, 'foo <em>bar</em>');
-  hydrateComponents([A]);
-  expect(document.body.innerHTML).toBe('<a>A</a>');
+	const { mounted } = init([A]);
+	document.body.innerHTML = createHTMLNode('a', mounted[0].vm, 'foo <em>bar</em>');
+	hydrateComponents([A]);
+	expect(document.body.innerHTML).toBe('<a>A</a>');
 });
 
 test('hydrates components with fitting markup', () => {
-  const {mounted} = init([A]);
-  document.body.innerHTML = createHTMLNode('a', mounted[0].vm, 'A');
-  hydrateComponents([A]);
-  expect(document.body.innerHTML).toBe('<a>A</a>');
+	const { mounted } = init([A]);
+	document.body.innerHTML = createHTMLNode('a', mounted[0].vm, 'A');
+	hydrateComponents([A]);
+	expect(document.body.innerHTML).toBe('<a>A</a>');
 });
 
 test('hydrates components with serialized props', () => {
-  init();
-  const mounted = mount(Handlebars, {propsData: {nickname: 'John Doe'}});
-  document.body.innerHTML = createHTMLNode('a', mounted.vm, 'A');
-  hydrateComponents([Handlebars]);
-  expect(document.body.innerHTML).toBe('<div>John Doe</div>');
+	init();
+	const mounted = mount(Handlebars, { propsData: { nickname: 'John Doe' } });
+	document.body.innerHTML = createHTMLNode('a', mounted.vm, 'A');
+	hydrateComponents([Handlebars]);
+	expect(document.body.innerHTML).toBe('<div>John Doe</div>');
 });
 
 test('hydrates components with serialized slots', () => {
-  init();
-  const SomeSlot = {
-    name: 'SomeSlot',
-    render: (h) => h('b', 'slot'),
-  };
-  const mounted = mount(WithSlots, {slots: {default: SomeSlot}});
-  document.body.innerHTML = createHTMLNode('a', mounted.vm, 'A');
-  hydrateComponents([WithSlots, SomeSlot]);
-  expect(document. body.innerHTML).toBe('<div><b>slot</b></div>');
-
+	init();
+	const SomeSlot = {
+		name: 'SomeSlot',
+		render: h => h('b', 'slot'),
+	};
+	const mounted = mount(WithSlots, { slots: { default: SomeSlot } });
+	document.body.innerHTML = createHTMLNode('a', mounted.vm, 'A');
+	hydrateComponents([WithSlots, SomeSlot]);
+	expect(document.body.innerHTML).toBe('<div><b>slot</b></div>');
 });
 
 test('hydrates components with existing attributes', () => {
-  const {mounted} = init([Wet]);
-  document.body.innerHTML = createHTMLNode('a', mounted[0].vm, 'A', {custom: "Stuff"});
-  hydrateComponents([Wet]);
-  expect(document.body.innerHTML).toBe('<div custom="Stuff">Got: Stuff</div>');
+	const { mounted } = init([Wet]);
+	document.body.innerHTML = createHTMLNode('a', mounted[0].vm, 'A', { custom: 'Stuff' });
+	hydrateComponents([Wet]);
+	expect(document.body.innerHTML).toBe('<div custom="Stuff">Got: Stuff</div>');
 });
 
-
-test("hydrates components with attribute props", () => {
-  const {mounted} = init([Handlebars]);
-  document.body.innerHTML = createHTMLNode('a', mounted[0].vm, '', {nickname: 'Bernd'});
-  hydrateComponents([Handlebars]);
-  expect(document.body.innerHTML).toBe('<div>Bernd</div>');
+test('hydrates components with attribute props', () => {
+	const { mounted } = init([Handlebars]);
+	document.body.innerHTML = createHTMLNode('a', mounted[0].vm, '', { nickname: 'Bernd' });
+	hydrateComponents([Handlebars]);
+	expect(document.body.innerHTML).toBe('<div>Bernd</div>');
 });
 
-test("hydrates components without attribute props", () => {
-  const {mounted} = init([HandlebarsNoProp]);
-  document.body.innerHTML = createHTMLNode('a', mounted[0].vm);
-  hydrateComponents([HandlebarsNoProp]);
-  expect(document.body.innerHTML).toMatch('<div></div>');
+test('hydrates components without attribute props', () => {
+	const { mounted } = init([HandlebarsNoProp]);
+	document.body.innerHTML = createHTMLNode('a', mounted[0].vm);
+	hydrateComponents([HandlebarsNoProp]);
+	expect(document.body.innerHTML).toMatch('<div></div>');
 });
 
-test("hydrates conditional components with attribute props", () => {
-  const {mounted} = init([Conditional]);
-  document.body.innerHTML = createHTMLNode('a', mounted[0].vm, '', {name: 'Bernd'});
-  hydrateComponents([Conditional]);
-  expect(document.body.innerHTML).toMatch('<div><b>Bernd</b></div>');
+test('hydrates conditional components with attribute props', () => {
+	const { mounted } = init([Conditional]);
+	document.body.innerHTML = createHTMLNode('a', mounted[0].vm, '', { name: 'Bernd' });
+	hydrateComponents([Conditional]);
+	expect(document.body.innerHTML).toMatch('<div><b>Bernd</b></div>');
 });
 
-test("hydrates conditional components without attribute props", () => {
-  const {mounted} = init([Conditional]);
-  document.body.innerHTML = createHTMLNode('a', mounted[0].vm);
-  hydrateComponents([Conditional]);
-  expect(document.body.innerHTML).toMatch('<div><i>No Name</i></div>');
+test('hydrates conditional components without attribute props', () => {
+	const { mounted } = init([Conditional]);
+	document.body.innerHTML = createHTMLNode('a', mounted[0].vm);
+	hydrateComponents([Conditional]);
+	expect(document.body.innerHTML).toMatch('<div><i>No Name</i></div>');
 });
 
 test('enables javascript on hydration', () => {
-  const {mounted} = init ([A]);
-  window.spy = jest.fn ();
-  document.body.innerHTML = createHTMLNode ('a', mounted[0].vm, 'A');
-  hydrateComponents ([A]);
-  document.querySelector ('a').click ();
-  expect (window.spy).toHaveBeenCalledWith ('A');
+	const { mounted } = init([A]);
+	window.spy = jest.fn();
+	document.body.innerHTML = createHTMLNode('a', mounted[0].vm, 'A');
+	hydrateComponents([A]);
+	document.querySelector('a').click();
+	expect(window.spy).toHaveBeenCalledWith('A');
 });
 
 test('throws error if 2 components have the same name', () => {
-  expect(() =>
-    hydrateComponents([A, B, AConflict, BConflict]),
-  ).toThrowErrorMatchingSnapshot();
+	expect(() => hydrateComponents([A, B, AConflict, BConflict])).toThrowErrorMatchingSnapshot();
 });
 
 test('logs a warning if a component is not provided for hydration', () => {
-   const spy = jest.spyOn(console, 'error').mockImplementation(() => {
-  });
-   document.body.innerHTML =
-    '<a data-hydrate-fingerprint="unknown-fp-1234">X</a><a data-hydrate-fingerprint="unknown-fp-4231">Y</a>';
-  hydrateComponents([A]);
-  expect(console.error).toHaveBeenCalledWith (
-    'Vue Moisturizer: You did not provide the component "unknown-fp-1234" in the client',
-  );
-  expect(console.error).toHaveBeenCalledWith (
-    'Vue Moisturizer: You did not provide the component "unknown-fp-4231" in the client',
-  );
-  spy.mockRestore();
+	const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
+	document.body.innerHTML =
+		'<a data-hydrate-fingerprint="unknown-fp-1234">X</a><a data-hydrate-fingerprint="unknown-fp-4231">Y</a>';
+	hydrateComponents([A]);
+	expect(console.error).toHaveBeenCalledWith(
+		'Vue Moisturizer: You did not provide the component "unknown-fp-1234" in the client'
+	);
+	expect(console.error).toHaveBeenCalledWith(
+		'Vue Moisturizer: You did not provide the component "unknown-fp-4231" in the client'
+	);
+	spy.mockRestore();
 });
 
 test('does not log warnings in production env', () => {
-  const spy = jest.spyOn (console, 'warn').mockImplementation (() => {
-  });
-  const orignalEnv = process.env.NODE_ENV;
-  process.env.NODE_ENV = 'production';
-  document.body.innerHTML =
-    '<a data-hydrate-fingerprint="unknown-fp-1234">X</a><a data-hydrate-fingerprint="unknown-fp-4231">Y</a>';
-  hydrateComponents ([A]);
-  expect (console.warn).not.toHaveBeenCalled ();
-  spy.mockRestore ();
-  process.env.NODE_ENV = orignalEnv;
+	const spy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+	const orignalEnv = process.env.NODE_ENV;
+	process.env.NODE_ENV = 'production';
+	document.body.innerHTML =
+		'<a data-hydrate-fingerprint="unknown-fp-1234">X</a><a data-hydrate-fingerprint="unknown-fp-4231">Y</a>';
+	hydrateComponents([A]);
+	expect(console.warn).not.toHaveBeenCalled();
+	spy.mockRestore();
+	process.env.NODE_ENV = orignalEnv;
 });
-

--- a/test/instantiateApp.test.js
+++ b/test/instantiateApp.test.js
@@ -1,19 +1,21 @@
-import Vue from "vue";
-import {instantiateApp} from "../lib/index";
-import App from "./fixtures/components/App.vue";
+import Vue from 'vue';
+import Moisturizer, { instantiateApp } from '../lib/index';
+import App from './fixtures/components/App.vue';
 
-test("returns a Vue instance without Vue options", () => {
-  expect(instantiateApp(App)).toBeInstanceOf(Vue);
+Vue.use(Moisturizer);
+
+test('returns a Vue instance without Vue options', () => {
+	expect(instantiateApp(App)).toBeInstanceOf(Vue);
 });
 
-test("returns a Vue instance with Vue options", () => {
-  const vueOptions = true;
-  const vueInstance = instantiateApp(App, { vueOptions });
-  expect(vueInstance.$options.vueOptions).toBe(vueOptions);
+test('returns a Vue instance with Vue options', () => {
+	const vueOptions = true;
+	const vueInstance = instantiateApp(App, { vueOptions });
+	expect(vueInstance.$options.vueOptions).toBe(vueOptions);
 });
 
-test("returns a Vue instance that can be rendered", () => {
-  document.body.innerHTML = '<div id="app"></div>';
-  instantiateApp(App).$mount("#app");
-  expect(document.body.innerHTML).toBe("<div>App</div>");
+test('returns a Vue instance that can be rendered', () => {
+	document.body.innerHTML = '<div id="app"></div>';
+	instantiateApp(App).$mount('#app');
+	expect(document.body.innerHTML).toBe('<div>App</div>');
 });

--- a/test/utils.js
+++ b/test/utils.js
@@ -5,28 +5,30 @@ import { createLocalVue, mount } from '@vue/test-utils';
 import MoisturizerVuePlugin from '../lib/moisturizerVuePlugin';
 
 export const createHTMLNode = (name, component, innerHtml = '', attributes = {}) => {
-  const fp = `fingerprint="${new Fingerprint (component).fingerprint()}"`;
-  const props = `props="${new Props(component).serialize(component.$props || [])}"`;
-  const slots = `slots="${new Slots(component).serialize(component.$slots || [])}"`;
-  const attrs = Object.keys(attributes).map(x => `${x}="${attributes[x]}"`);
+	const fp = `fingerprint="${new Fingerprint(component).fingerprint()}"`;
+	const props = `props="${new Props(component).serialize(component.$props || [])}"`;
+	const slots = `slots="${new Slots(component).serialize(component.$slots || [])}"`;
+	const attrs = Object.keys(attributes).map(x => `${x}="${attributes[x]}"`);
 
-  return `<${name} ` +
-    [fp, props, slots].map(x => 'data-hydrate-' + x).join(' ')
-    + (!attrs ? '' : ' ' + attrs.join(' '))
-    + `>${innerHtml}</${name}>`;
+	return (
+		`<${name} ` +
+		[fp, props, slots].map(x => 'data-hydrate-' + x).join(' ') +
+		(!attrs ? '' : ' ' + attrs.join(' ')) +
+		`>${innerHtml}</${name}>`
+	);
 };
 
 export const setLocalVueEnv = (localVue, isServer) => {
-  Object.defineProperty (localVue.prototype, '$isServer', {
-    get: () => isServer,
-  });
+	Object.defineProperty(localVue.prototype, '$isServer', {
+		get: () => isServer,
+	});
 };
 
 export const init = (components = []) => {
-  const localVue = createLocalVue ();
-  const isServer = true;
-  setLocalVueEnv (localVue, isServer);
-  localVue.use (MoisturizerVuePlugin);
-  const mounted = components.map (c => mount (c));
-  return { mounted, localVue };
+	const localVue = createLocalVue();
+	const isServer = true;
+	setLocalVueEnv(localVue, isServer);
+	localVue.use(MoisturizerVuePlugin);
+	const mounted = components.map(c => mount(c));
+	return { mounted, localVue };
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2011,6 +2011,11 @@ has-ansi@^2.0.0:
   dependencies:
     ansi-regex "^2.0.0"
 
+has-duplicates@1.0.0:
+  version "1.0.0"
+  resolved "https://spring.jfrog.io/spring/api/npm/npm-red/has-duplicates/-/has-duplicates-1.0.0.tgz#8930761db2f71f39ba89c05b0b158ab484eb9710"
+  integrity sha1-iTB2HbL3Hzm6icBbCxWKtITrlxA=
+
 has-flag@^1.0.0:
   version "1.0.0"
   resolved "https://spring.jfrog.io/spring/api/npm/npm-red/has-flag/-/has-flag-1.0.0.tgz#9d9e793165ce017a00f00418c43f942a7b1d11fa"


### PR DESCRIPTION
Instead of its own `Vue` npm dependency we now use the `Vue` we get when someone does `Vue.use(Moisturizer)`