### PR TITLE
RED-1811: Fixed deserialisation error when source data contains "&quot;"

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "vue-plugin-moisturizer",
-	"version": "1.2.7",
+	"version": "1.2.8",
 	"main": "lib/index.js",
 	"author": "Lukas Bombach",
 	"license": "MIT",

--- a/src/hydrator.js
+++ b/src/hydrator.js
@@ -24,7 +24,14 @@ class Hydrator {
 	}
 
 	mount(component, el) {
-		const props = new Props(this.components).getFromElement(el);
+		let props;
+		try {
+			props = new Props(this.components).getFromElement(el);
+		} catch (err) {
+			console.error('Failed to hydrate component: ', err);
+			return;
+		}
+
 		const slots = new Slots(this.components).getFromElement(el);
 		const htmlAttrs = [...el.attributes].filter(a => !a.name.startsWith('data-hydrate'));
 		const attrObjects = [...htmlAttrs].map(attr => ({ [attr.name]: attr.value }));

--- a/src/props.js
+++ b/src/props.js
@@ -73,7 +73,12 @@ class Props {
 		const attr = el.getAttribute(config.attrs.props);
 		const json = (attr && attr.replace(/'/g, '"').replace(/&quot;/g, '"')) || '"{}"';
 
-		return JSON.parse(json);
+		try {
+			return JSON.parse(json);
+		} catch (err) {
+			console.error('Failed to deserialize props from JSON: ', json);
+			throw err;
+		}
 	}
 }
 

--- a/src/props.js
+++ b/src/props.js
@@ -48,7 +48,7 @@ class Props {
 
 	stringifyForAttr(props) {
 		const json = JSON.stringify(props);
-		return json.replace(/'/g, "\\'").replace(/"/g, "&quot;");
+		return json.replace(/'/g, "\\'").replace(/"/g, "&escapedquot;");
 	}
 
 	sanitizeProps(props) {
@@ -71,7 +71,7 @@ class Props {
 
 	readPropsFromEl(el) {
 		const attr = el.getAttribute(config.attrs.props);
-		const json = (attr && attr.replace(/'/g, '"').replace(/&quot;/g, '"')) || '"{}"';
+		const json = (attr && attr.replace(/'/g, '"').replace(/&escapedquot;/g, '"')) || '"{}"';
 
 		try {
 			return JSON.parse(json);


### PR DESCRIPTION
The code originally used the sequence `&quot;` to escape double quotes from the source data. When reading the data back in, all `&quot;` sequences in the source data were replaced with double quotes again.

This would cause an error if the original text had already contained the `&quot;` sequence as it would produce invalid JSON (the JSON would contain an unescaped double quote).

To prevent similar errors from breaking other components on the page in the future, some error handling was added.